### PR TITLE
adding error code '4' into cordova_media_capture

### DIFF
--- a/cordova-plugin-media-capture.opam
+++ b/cordova-plugin-media-capture.opam
@@ -6,7 +6,7 @@ homepage:     "git+https://github.com/dannywillems/ocaml-cordova-plugin-media-ca
 bug-reports:  "git+https://github.com/dannywillems/ocaml-cordova-plugin-media-capture/issues"
 dev-repo:     "git+https://github.com/dannywillems/ocaml-cordova-plugin-media-capture"
 license:      "LGPL-3.0 with OCaml linking exception"
-version:      "1.0"
+version:      "1.1"
 description: "Binding to the media-capture cordova plugin using gen_js_api"
 synopsis: "Binding to the media-capture cordova plugin using gen_js_api"
 build: [[ "dune" "build" "-j" jobs "-p" name "@install" ]]

--- a/src/cordova_media_capture.mli
+++ b/src/cordova_media_capture.mli
@@ -4,6 +4,7 @@ type error_type =
   | Application_busy [@js 1]
   | Invalid_argument [@js 2]
   | No_media_files [@js 3]
+  | Capture_permission_denied [@js 4]
   | Not_supported [@js 20]
 [@@js.enum]
 


### PR DESCRIPTION
Their is missing error types in the original repository.